### PR TITLE
Adding required usage description (since iOS10)

### DIFF
--- a/BarcodeScanner/BarcodeScanner/Info.plist
+++ b/BarcodeScanner/BarcodeScanner/Info.plist
@@ -44,5 +44,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>QRCode scanner</string>
 </dict>
 </plist>


### PR DESCRIPTION
Application will crash at runtime without description (no end user message displayed, only an error in the debug console)